### PR TITLE
Add formData to FileUpload options

### DIFF
--- a/js/backbone.upload-manager.js
+++ b/js/backbone.upload-manager.js
@@ -53,6 +53,7 @@
             this.uploadProcess = $('<input id="fileupload" type="file" name="files[]" multiple="multiple">').fileupload({
                 dataType: 'json',
                 url: this.options.uploadUrl,
+                formData: this.options.formData,
                 autoUpload: this.options.autoUpload,
                 singleFileUploads: true
             });


### PR DESCRIPTION
By sending formData we can add additional data with each file upload, that could be very useful when handling the upload at the server side.
