### PR TITLE
improved performance for jquery, fixed styling by adding prefixes

### DIFF
--- a/css/backbone.upload-manager.css
+++ b/css/backbone.upload-manager.css
@@ -1,7 +1,11 @@
 .upload-manager {
     border: 1px solid #CCCCCC;
     border-radius: 4px 4px 4px 4px;
+    -webkit-border-radius: 4px 4px 4px 4px;
+    -moz-border-radius: 4px 4px 4px 4px;
     box-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
+    -webkit-box-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
+    -moz-box-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
     text-align: left;
 }
 .upload-manager footer {
@@ -15,10 +19,16 @@
     font-size: 23px;
     margin: 0;
     opacity: 0;
+    -webkit-opacity: 0;
+    -moz-opacity: 0;
     position: absolute;
     right: 0;
     top: 0;
     transform: translate(-300px, 0px) scale(4);
+    -webkit-transform: translate(-300px, 0px) scale(4);
+    -moz-transform: translate(-300px, 0px) scale(4);
+    -ms-transform: translate(-300px, 0px) scale(4);
+    -o-transform: translate(-300px, 0px) scale(4);
 }
 .upload-manager .fileinput-button {
     overflow: hidden;
@@ -30,10 +40,10 @@
 .upload-manager .message.done {
     color: #57ba48;
 }
-.upload-manager div.progress {
+.upload-manager .progress {
     position: relative;
 }
-.upload-manager div.progress div.progress-label {
+.upload-manager .progress .progress-label {
     position: absolute; 
     width: 100%; 
     text-align: center;
@@ -48,22 +58,22 @@
     height: 16px;
     width: 16px;
 }
-.upload-manager i.icon-cancel {
+.upload-manager .icon-cancel {
     background-position: 0 0;
 }
-.upload-manager i.icon-start {
+.upload-manager .icon-start {
     background-position: -32px 0;
 }
-.upload-manager i.icon-plus {
+.upload-manager .icon-plus {
     background-position: -80px 0;
 }
-.upload-manager i.icon-error {
+.upload-manager .icon-error {
     background-position: -96px 0;
 }
-.upload-manager i.icon-success {
+.upload-manager .icon-success {
     background-position: -112px 0;
 }
-.upload-manager i.icon-remove {
+.upload-manager .icon-remove {
     background-position: -144px 0;
 }
 

--- a/js/backbone.upload-manager.js
+++ b/js/backbone.upload-manager.js
@@ -1,3 +1,4 @@
+
 /**
  * Backbone Upload Manager v1.0.0
  *
@@ -110,7 +111,7 @@
          */
         update: function ()
         {
-            var with_files_elements = $('button#' + this.options.cancelUploadsId + ', button#' + this.options.startUploadsId, this.el);
+            var with_files_elements = $('#' + this.options.cancelUploadsId + ', #' + this.options.startUploadsId, this.el);
             var without_files_elements = $('#file-list .no-data', this.el);
             if (this.files.length > 0) {
                 with_files_elements.removeClass('hidden');
@@ -192,7 +193,7 @@
             this.update();
 
             // Add add files handler
-            var input = $('input#' + this.options.fileUploadId, this.el), self = this;
+            var input = $('#' + this.options.fileUploadId, this.el), self = this;
             input.on('change', function (){
                 self.uploadProcess.fileupload('add', {
                     fileInput: $(this)
@@ -200,14 +201,14 @@
             });
 
             // Add cancel all handler
-            $('button#' + this.options.cancelUploadsId, this.el).click(function(){
+            $('#' + this.options.cancelUploadsId, this.el).click(function(){
                 while (self.files.length) {
                     self.files.at(0).cancel();
                 }
             });
 
             // Add start uploads handler
-            $('button#' + this.options.startUploadsId, this.el).click(function(){
+            $('#' + this.options.startUploadsId, this.el).click(function(){
                 self.files.each(function(file){
                     file.start();
                 });
@@ -390,7 +391,7 @@
                 var progressHTML = this.getHelpers().displaySize(progress.loaded)+' of '+this.getHelpers().displaySize(progress.total);
                 if (percent >= 100 && this.processUploadMsg) { progressHTML = this.processUploadMsg; }
 
-                $('div.progress', this.el)
+                $('.progress', this.el)
                     .find('.bar')
                     .css('width', percent+'%')
                     .parent()
@@ -404,7 +405,7 @@
              */
             hasFailed: function (error)
             {
-                $('span.message', this.el).html('<i class="icon-error"></i> '+error);
+                $('.message', this.el).html('<i class="icon-error"></i> '+error);
             },
 
             /**
@@ -413,7 +414,7 @@
              */
             hasDone: function (result)
             {
-                $('span.message', this.el).html('<i class="icon-success"></i> ' + (this.doneMsg || 'Uploaded'));
+                $('.message', this.el).html('<i class="icon-success"></i> ' + (this.doneMsg || 'Uploaded'));
             },
 
             /**
@@ -422,9 +423,9 @@
              */
             update: function ()
             {
-                var when_pending = $('span.size, button#btn-cancel', this.el),
-                    when_running = $('div.progress, button#btn-cancel', this.el),
-                    when_done = $('span.message, button#btn-clear', this.el);
+                var when_pending = $('.size, #btn-cancel', this.el),
+                    when_running = $('.progress, #btn-cancel', this.el),
+                    when_done = $('.message, #btn-clear', this.el);
 
                 if (this.model.isPending()) {
                     when_running.add(when_done).addClass('hidden');
@@ -447,14 +448,14 @@
                 var self = this;
 
                 // DOM events
-                $('button#btn-cancel', this.el).click(function(){
+                $('#btn-cancel', this.el).click(function(){
                     self.model.cancel();
                     self.collection.remove(self.model);
                 });
-                $('button#btn-clear', this.el).click(function(){
+                $('#btn-clear', this.el).click(function(){
                     self.model.destroy();
                     self.collection.remove(self.model);
-                })
+                });
             },
 
             /**


### PR DESCRIPTION
Removed node names from jQuery selection.
-> it's faster. jQuery will optimize when given just the id, `document.getElementById` 
-> it allows UI peeps to use other elements besides buttons. What if they want to use an a tag, etc? 
-> it's good practice. 

Cleaned styling and added prefixes
-> will improve cross-browser/ device niceness
-> faster CSS specificity

Also, hi. Let me know if I need to meet any project standards. 

Edit: added commit for styling
